### PR TITLE
Update JCAnnotationView.m

### DIFF
--- a/JCTiledScrollView/Source/JCAnnotationView.m
+++ b/JCTiledScrollView/Source/JCAnnotationView.m
@@ -35,7 +35,7 @@
 {
   if ((self = [super initWithFrame:frame]))
   {
-    _centerOffset = CGPointZero;
+    _centerOffset = CGPointMake(0,-30);
     _position = CGPointZero;
     _annotation = annotation;
     _reuseIdentifier = reuseIdentifier;


### PR DESCRIPTION
Workaround for correct annotation center point.

Original annotation is drawn with its center at image top, it should be at image bottom. You see difference when you create random annotations and zoom in and out.

Maybe there is a better place for this correction, like using the method "setCenterOffset" in JCAnnotationView.m?