### PR TITLE
Fix correct annotation center point in the demo

### DIFF
--- a/Demo/JCTiledViewDemo/RootViewController.swift
+++ b/Demo/JCTiledViewDemo/RootViewController.swift
@@ -145,6 +145,7 @@ class RootViewController: UIViewController, JCTileSource, JCTiledScrollViewDeleg
     
     let annotationView = DemoAnnotationView(frame:.zero, annotation:annotation, reuseIdentifier: "ReuseIdentifier")
     annotationView.imageView?.image = UIImage(named:"marker-red.png")
+    annotationView.centerOffset = CGPoint(x: 0, y: -30)
     annotationView.sizeToFit()
     
     return annotationView


### PR DESCRIPTION
Fix annotation center point.

Original annotation is drawn with its center at image top, it should be at image bottom. You see difference when you create random annotations and zoom in and out.