### PR TITLE
Supports changing tile size from default 256x256

### DIFF
--- a/Headers/JCTiledLayer.h
+++ b/Headers/JCTiledLayer.h
@@ -25,4 +25,5 @@
 #import <QuartzCore/QuartzCore.h>
 
 @interface JCTiledLayer : CATiledLayer
+@property (atomic, assign) CGSize tileSize;
 @end

--- a/Headers/JCTiledView.h
+++ b/Headers/JCTiledView.h
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface JCTiledView : UIView
 
 @property (nonatomic, weak, nullable) id<JCTiledViewDelegate> delegate;
-@property (nonatomic, readonly) CGSize tileSize;
+@property (nonatomic, assign) CGSize tileSize;
 @property (nonatomic, assign) size_t numberOfZoomLevels;
 @property (nonatomic, assign) BOOL shouldAnnotateRect;
 

--- a/JCTiledScrollView/Source/JCTiledLayer.m
+++ b/JCTiledScrollView/Source/JCTiledLayer.m
@@ -27,6 +27,7 @@
 static const CFTimeInterval kDefaultFadeDuration = 0.08;
 
 @implementation JCTiledLayer
+@synthesize tileSize = _tileSize;
 
 + (CFTimeInterval)fadeDuration
 {

--- a/JCTiledScrollView/Source/JCTiledView.m
+++ b/JCTiledScrollView/Source/JCTiledView.m
@@ -34,7 +34,7 @@ static const CGFloat kDefaultTileSize = 256.0f;
 
 @implementation JCTiledView
 
-@dynamic tileSize;
+@synthesize tileSize = _tileSize;
 @synthesize delegate = _delegate;
 @synthesize shouldAnnotateRect = _shouldAnnotateRect;
 
@@ -49,6 +49,7 @@ static const CGFloat kDefaultTileSize = 256.0f;
   {
     self.numberOfZoomLevels = 3;
     self.shouldAnnotateRect = NO;
+    self.tileSize = CGSizeMake(kDefaultTileSize, kDefaultTileSize);
   }
   return self;
 }
@@ -57,12 +58,9 @@ static const CGFloat kDefaultTileSize = 256.0f;
 
 - (JCTiledLayer *)tiledLayer
 {
-  return (JCTiledLayer *)self.layer;
-}
-
-- (CGSize)tileSize
-{
-  return CGSizeMake(kDefaultTileSize, kDefaultTileSize);
+  JCTiledLayer * modifiedLayer = (JCTiledLayer *) self.layer;
+  modifiedLayer.tileSize = self.tileSize;
+  return modifiedLayer;
 }
 
 - (size_t)numberOfZoomLevels


### PR DESCRIPTION
Will allow changing tileSize from swift code and also set correct size in JCTiledLayer (or tiles will have wrong resolution on the phone).
Tested with 512x512 tiles

Use like this:
let scrollView = JCTiledScrollView(frame: self.view.frame, contentSize: imageSize)
scrollView.tiledView.tileSize = CGSize(width: CGFloat(256.0), height: CGFloat(256.0))